### PR TITLE
Add homebrew setup

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,6 +46,9 @@ jobs:
     - name: Clean generated code
       run: rm -rf pkg
 
+    - name: Set up Homebrew
+      uses: Homebrew/actions/setup-homebrew@master
+
     - name: Install Buf
       run: brew install bufbuild/buf/buf
 


### PR DESCRIPTION
GH actions removed homebrew from PATH in linux containers[1] 
Update the workflow to setup homebrew before using it

[1] - https://github.com/actions/runner-images/issues/6283